### PR TITLE
Fix failing validation

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -29,9 +29,9 @@ class Gateway extends AbstractGateway
     public function getDefaultParameters()
     {
         return [
-            'tokenCode' => '',
-            'apiToken' => '',
-            'serviceId' => ''
+            'tokenCode' => null,
+            'apiToken' => null,
+            'serviceId' => null
         ];
     }
 


### PR DESCRIPTION
When settings default parameters to empty string, the validation will see them as valid (because they exists)
When setting them to null the validation properly catches missing values as intended