### PR TITLE
Allow language to be set for a payment request.

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -27,6 +27,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('serviceId', $value);
     }
 
+    /**
+     * @param  string $value
+     *
+     * @return $this
+     */
+    public function setLanguage($value)
+    {
+        return $this->setParameter('language', $value);
+    }
+
     protected function sendRequest($method, $endpoint, array $data = array())
     {
         $data['token']     = $this->getApitoken();
@@ -53,6 +63,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function getServiceId()
     {
         return $this->getParameter('serviceId');
+    }
+
+    /**
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->getParameter('language');
     }
 
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -54,7 +54,7 @@ class PurchaseRequest extends AbstractRequest {
                 'dob' => $card->getBirthday('d-m-Y'),
                 'phoneNumber' => $card->getPhone(),
                 'emailAddress' => $card->getEmail(),
-                'language' => $card->getBillingCountry(),
+                'language' => $this->getLanguage() ? $this->getLanguage() : $card->getBillingCountry(),
                 'address' => array(
                     'streetName' => isset($shippingAddressParts[1]) ? $shippingAddressParts[1] : null,
                     'streetNumber' => isset($shippingAddressParts[2]) ? $shippingAddressParts[2] : null,

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -55,6 +55,14 @@ class PurchaseRequestTest extends TestCase
         $this->assertEquals('USD', $data['transaction']['currency']);
     }
 
+    public function testLanguage(){
+        $this->request->setLanguage('NL');
+        $data = $this->request->getData();
+
+        $this->assertArrayHasKey('enduser', $data);
+        $this->assertEquals('NL', $data['enduser']['language']);
+    }
+
     public function testWithCardOnlyShipping(){
         $arrCard = $this->getValidCard();
 


### PR DESCRIPTION
For a belgian customer we would like to be able to set the language to french without having to depend on the billing country. I assume that setting the language here will reflect upon the language of for example bancontact.